### PR TITLE
Fix null check for subitems in EPubParser

### DIFF
--- a/src/lib/epub/EPubParser.ts
+++ b/src/lib/epub/EPubParser.ts
@@ -332,8 +332,8 @@ export class EPubParser {
       if (item.href.endsWith(href)) {
         return item;
       }
-      if (item.subItems!.length > 0) {
-        const found = this.findTocItem(item.subItems!, href);
+      if (item.subItems?.length) {
+        const found = this.findTocItem(item.subItems, href);
         if (found) {
           return found;
         }


### PR DESCRIPTION
## Summary
- handle undefined `subItems` in `EPubParser.findTocItem`

## Testing
- `bun test` *(fails: Cannot find package 'yauzl'; Cannot find package 'jszip')*