### PR TITLE
Refactor EPUB parser file reading

### DIFF
--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,0 +1,10 @@
+import TurndownService from 'turndown';
+
+export function createTurndownService(): TurndownService {
+  const td = new TurndownService({ headingStyle: 'atx' });
+  td.addRule('pageBreak', {
+    filter: (node) => node.nodeName === 'SPAN' && node.classList.contains('page-break'),
+    replacement: () => '\n\n---\n\n'
+  });
+  return td;
+}


### PR DESCRIPTION
## Summary
- add internal `readFileFromZip` helper for `EPubParser`
- refactor XML readers to use the new helper

## Testing
- `bun test` *(fails: Cannot find package 'yauzl'/'jszip')*
