### PR TITLE
Fix pnpm check errors

### DIFF
--- a/src/cli/dumpEpub.ts
+++ b/src/cli/dumpEpub.ts
@@ -84,8 +84,7 @@ async function dumpSingle(epubPath: string, dumpDir: string) {
 	const td = createTurndownService();
 
 	// write chapters
-	for (let i = 0; i < chapters.length; i++) {
-		const chapter = chapters[i]!;
+	for (const [i, chapter] of chapters.entries()) {
 		const baseName = `${String(i + 1).padStart(4, "0")}_${slug(
 			chapter.title || chapter.id || chapter.href,
 		)}`;

--- a/src/cli/unzipEpub.ts
+++ b/src/cli/unzipEpub.ts
@@ -19,8 +19,12 @@ async function main() {
 		console.log(`Extracting ${absolutePath} to ${targetDir}`);
 		await extractZip(absolutePath, targetDir);
 		console.log("Done!");
-	} catch (error: any) {
-		console.error("Error:", error.message);
+	} catch (error) {
+		if (error instanceof Error) {
+			console.error("Error:", error.message);
+		} else {
+			console.error("Unknown error:", error);
+		}
 		process.exit(1);
 	}
 }

--- a/src/lib/epub/extractZip.ts
+++ b/src/lib/epub/extractZip.ts
@@ -53,8 +53,8 @@ export async function extractZip(
 		});
 
 	try {
-		let entry: yauzl.Entry | null;
-		while ((entry = await nextEntry()) !== null) {
+		let entry: yauzl.Entry | null = await nextEntry();
+		while (entry !== null) {
 			const fullPath = path.join(targetDir, entry.fileName);
 			const directory = path.dirname(fullPath);
 
@@ -66,6 +66,7 @@ export async function extractZip(
 				const writeStream = createWriteStream(fullPath);
 				await pipeline(readStream, writeStream);
 			}
+			entry = await nextEntry();
 		}
 	} finally {
 		zipfile.close();


### PR DESCRIPTION
## Summary
- fix unzip error handling
- avoid assignment in while condition when extracting zips
- iterate chapters without non-null assertions
- type EPUB parsing to avoid `any`

## Testing
- `pnpm check`