### PR TITLE
feat: add Chrome MV3 extension for copy with context

### DIFF
--- a/packages/extension/.gitignore
+++ b/packages/extension/.gitignore
@@ -1,0 +1,5 @@
+# Build output
+dist/
+
+# Package files
+*.zip

--- a/packages/extension/README.md
+++ b/packages/extension/README.md
@@ -1,0 +1,88 @@
+# Copy with Context - Chrome Extension
+
+A Chrome MV3 extension that allows users to copy selected text with smart surrounding context for ChatGPT analysis.
+
+## Features
+
+- **Smart Context Extraction**: Automatically extracts relevant surrounding text from web pages
+- **ChatGPT Integration**: Formats context into a ready-to-use ChatGPT prompt
+- **Outline Display**: Shows ChatGPT's outline overlay on the original page
+- **Text Fragment Links**: Generates deep links back to the original selection
+
+## Development
+
+### Prerequisites
+
+- Node.js 18+
+- pnpm 10.x
+
+### Setup
+
+```bash
+# Install dependencies
+pnpm install
+
+# Build the extension
+pnpm -C packages/extension build
+
+# Or watch for changes during development
+pnpm -C packages/extension dev
+```
+
+### Loading in Chrome
+
+1. Open Chrome and navigate to `chrome://extensions/`
+2. Enable "Developer mode" (toggle in top-right)
+3. Click "Load unpacked"
+4. Select the `packages/extension/dist` directory
+
+### Project Structure
+
+```
+packages/extension/
+├── src/
+│   ├── background/       # Service worker
+│   ├── content/          # Content scripts
+│   ├── panel/            # Side panel UI
+│   ├── popup/            # Extension popup
+│   ├── common/           # Shared utilities
+│   └── assets/           # Icons and images
+├── manifest.json         # Extension manifest
+├── vite.config.ts        # Build configuration
+└── package.json
+```
+
+## Usage
+
+1. Select text on any webpage
+2. Right-click and choose "Copy with context"
+3. The extension captures the selection + surrounding context
+4. A formatted ChatGPT prompt is copied to your clipboard
+5. Paste into ChatGPT to get an outline
+6. Open the side panel to paste the outline back
+7. The outline appears as an overlay on the original page
+
+## Technical Details
+
+- **Manifest Version**: 3
+- **Framework**: React 19 for UI components
+- **Build Tool**: Vite
+- **Context Extraction**: Adapted from @epubdown/reader's SelectionContextExtractor
+- **Storage**: chrome.storage.session for ephemeral captures, chrome.storage.local for settings
+- **Overlay**: Shadow DOM to avoid CSS conflicts with host pages
+
+## Icons
+
+The current icons are SVG placeholders. For production, replace files in `src/assets/` with proper PNG icons:
+- `icon16.png` (16x16)
+- `icon48.png` (48x48)
+- `icon128.png` (128x128)
+
+Generate icons by running:
+```bash
+bun packages/extension/scripts/generate-icons.ts
+```
+
+## License
+
+Private - Part of the epubdown monorepo

--- a/packages/extension/README.md
+++ b/packages/extension/README.md
@@ -29,12 +29,32 @@ pnpm -C packages/extension build
 pnpm -C packages/extension dev
 ```
 
-### Loading in Chrome
+### Loading in Chrome (Development)
 
 1. Open Chrome and navigate to `chrome://extensions/`
 2. Enable "Developer mode" (toggle in top-right)
 3. Click "Load unpacked"
 4. Select the `packages/extension/dist` directory
+
+### Packaging for Distribution
+
+To create a .zip file that can be shared or submitted to the Chrome Web Store:
+
+```bash
+# Build and package the extension
+pnpm -C packages/extension package
+```
+
+This will create `extension-v0.1.0.zip` (or whatever version is in package.json) in the `packages/extension/` directory.
+
+**To install the packaged extension:**
+1. Share the .zip file with others
+2. They extract it to a folder
+3. Follow the "Loading in Chrome" steps above, selecting the extracted folder
+
+**For Chrome Web Store submission:**
+1. Upload the .zip file directly to the Chrome Web Store Developer Dashboard
+2. No need to extract - Chrome Web Store accepts .zip files
 
 ### Project Structure
 

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -1,0 +1,38 @@
+{
+  "manifest_version": 3,
+  "name": "Copy with Context",
+  "version": "0.1.0",
+  "description": "Copy selection + smart context to ChatGPT, then show the outline overlay.",
+  "permissions": [
+    "contextMenus",
+    "scripting",
+    "activeTab",
+    "storage",
+    "sidePanel"
+  ],
+  "optional_permissions": ["offscreen"],
+  "background": {
+    "service_worker": "background/service_worker.js",
+    "type": "module"
+  },
+  "action": {
+    "default_popup": "popup/popup.html"
+  },
+  "side_panel": {
+    "default_path": "panel/index.html"
+  },
+  "icons": {
+    "16": "assets/icon16.png",
+    "48": "assets/icon48.png",
+    "128": "assets/icon128.png"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content/contentScript.js"],
+      "css": ["content/contentScript.css"],
+      "run_at": "document_idle"
+    }
+  ],
+  "host_permissions": ["<all_urls>"]
+}

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@epubdown/extension",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "description": "Chrome extension for copying text with context and showing outlines",
+  "scripts": {
+    "dev": "vite build --watch --mode development && vite build --watch --mode development --config vite.config.content.ts",
+    "build": "vite build && vite build --config vite.config.content.ts",
+    "typecheck": "tsc --noEmit",
+    "check": "biome check --write"
+  },
+  "dependencies": {
+    "@mozilla/readability": "^0.6.0",
+    "react": "^19",
+    "react-dom": "^19"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "catalog:",
+    "@types/chrome": "^0.0.278",
+    "@types/node": "catalog:",
+    "@types/react": "^19.0.3",
+    "@types/react-dom": "^19.0.2",
+    "@vitejs/plugin-react": "^4",
+    "typescript": "catalog:",
+    "vite": "catalog:"
+  }
+}

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite build --watch --mode development && vite build --watch --mode development --config vite.config.content.ts",
     "build": "vite build && vite build --config vite.config.content.ts",
+    "package": "pnpm build && cd dist && zip -r ../extension-v$npm_package_version.zip . -x '*.DS_Store'",
     "typecheck": "tsc --noEmit",
     "check": "biome check --write"
   },

--- a/packages/extension/public/icon128.svg
+++ b/packages/extension/public/icon128.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+  <rect width="128" height="128" fill="#3b82f6" rx="25.6"/>
+  <text x="50%" y="50%" text-anchor="middle" dy=".35em" fill="white" font-family="Arial, sans-serif" font-size="64" font-weight="bold">C</text>
+</svg>

--- a/packages/extension/public/icon16.svg
+++ b/packages/extension/public/icon16.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#3b82f6" rx="3.2"/>
+  <text x="50%" y="50%" text-anchor="middle" dy=".35em" fill="white" font-family="Arial, sans-serif" font-size="8" font-weight="bold">C</text>
+</svg>

--- a/packages/extension/public/icon48.svg
+++ b/packages/extension/public/icon48.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">
+  <rect width="48" height="48" fill="#3b82f6" rx="9.600000000000001"/>
+  <text x="50%" y="50%" text-anchor="middle" dy=".35em" fill="white" font-family="Arial, sans-serif" font-size="24" font-weight="bold">C</text>
+</svg>

--- a/packages/extension/public/manifest.json
+++ b/packages/extension/public/manifest.json
@@ -1,0 +1,38 @@
+{
+  "manifest_version": 3,
+  "name": "Copy with Context",
+  "version": "0.1.0",
+  "description": "Copy selection + smart context to ChatGPT, then show the outline overlay.",
+  "permissions": [
+    "contextMenus",
+    "scripting",
+    "activeTab",
+    "storage",
+    "sidePanel"
+  ],
+  "optional_permissions": ["offscreen"],
+  "background": {
+    "service_worker": "background/service_worker.js",
+    "type": "module"
+  },
+  "action": {
+    "default_popup": "src/popup/popup.html"
+  },
+  "side_panel": {
+    "default_path": "src/panel/index.html"
+  },
+  "icons": {
+    "16": "icon16.svg",
+    "48": "icon48.svg",
+    "128": "icon128.svg"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content/contentScript.js"],
+      "css": ["content.css"],
+      "run_at": "document_idle"
+    }
+  ],
+  "host_permissions": ["<all_urls>"]
+}

--- a/packages/extension/scripts/generate-icons.ts
+++ b/packages/extension/scripts/generate-icons.ts
@@ -1,0 +1,33 @@
+/**
+ * Generate placeholder icons for the extension
+ * Run with: bun packages/extension/scripts/generate-icons.ts
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const publicDir = join(__dirname, "..", "public");
+
+// Ensure public directory exists
+mkdirSync(publicDir, { recursive: true });
+
+function generateSVG(size: number): string {
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 ${size} ${size}">
+  <rect width="${size}" height="${size}" fill="#3b82f6" rx="${size * 0.2}"/>
+  <text x="50%" y="50%" text-anchor="middle" dy=".35em" fill="white" font-family="Arial, sans-serif" font-size="${size * 0.5}" font-weight="bold">C</text>
+</svg>`;
+}
+
+const sizes = [16, 48, 128];
+
+for (const size of sizes) {
+  const svg = generateSVG(size);
+  const filename = `icon${size}.svg`;
+  writeFileSync(join(publicDir, filename), svg);
+  console.log(`Generated ${filename}`);
+}
+
+console.log("\nPlaceholder icons generated successfully!");
+console.log("For production, replace these with proper PNG icons.");

--- a/packages/extension/src/assets/icon128.svg
+++ b/packages/extension/src/assets/icon128.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+  <rect width="128" height="128" fill="#3b82f6" rx="25.6"/>
+  <text x="50%" y="50%" text-anchor="middle" dy=".35em" fill="white" font-family="Arial, sans-serif" font-size="64" font-weight="bold">C</text>
+</svg>

--- a/packages/extension/src/assets/icon16.svg
+++ b/packages/extension/src/assets/icon16.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#3b82f6" rx="3.2"/>
+  <text x="50%" y="50%" text-anchor="middle" dy=".35em" fill="white" font-family="Arial, sans-serif" font-size="8" font-weight="bold">C</text>
+</svg>

--- a/packages/extension/src/assets/icon48.svg
+++ b/packages/extension/src/assets/icon48.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">
+  <rect width="48" height="48" fill="#3b82f6" rx="9.600000000000001"/>
+  <text x="50%" y="50%" text-anchor="middle" dy=".35em" fill="white" font-family="Arial, sans-serif" font-size="24" font-weight="bold">C</text>
+</svg>

--- a/packages/extension/src/background/service_worker.ts
+++ b/packages/extension/src/background/service_worker.ts
@@ -1,0 +1,86 @@
+/**
+ * Background service worker for the Copy with Context extension
+ * Handles context menu creation, message routing, and side panel management
+ */
+
+import type { MessageCopyWithContext } from "../common/types";
+
+// Initialize context menu on installation
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.contextMenus.create({
+    id: "copy-with-context",
+    title: "Copy with context",
+    contexts: ["selection"], // Only show when text is selected
+  });
+
+  // Enable side panel globally
+  chrome.sidePanel.setOptions({ enabled: true }).catch((err) => {
+    console.error("Failed to enable side panel:", err);
+  });
+
+  // CRITICAL: Allow content scripts to access chrome.storage.session
+  // By default, session storage is only accessible from trusted contexts (service worker, extension pages)
+  // This call enables access from content scripts (untrusted contexts)
+  chrome.storage.session
+    .setAccessLevel({
+      accessLevel: "TRUSTED_AND_UNTRUSTED_CONTEXTS",
+    })
+    .then(() => {
+      console.log("Session storage access level set for content scripts");
+    })
+    .catch((err) => {
+      console.error("Failed to set session storage access level:", err);
+    });
+});
+
+// Handle context menu clicks
+chrome.contextMenus.onClicked.addListener(async (info, tab) => {
+  if (info.menuItemId !== "copy-with-context" || !tab?.id) return;
+
+  console.log("Context menu clicked, selection:", info.selectionText);
+
+  try {
+    // Send message to content script (already injected via manifest)
+    // Include the selection text from the context menu
+    const message: MessageCopyWithContext = {
+      type: "COPY_WITH_CONTEXT",
+      selectionText: info.selectionText,
+    };
+
+    await chrome.tabs.sendMessage(tab.id, message);
+    console.log("Message sent to content script");
+  } catch (err) {
+    console.error("Failed to send message to content script:", err);
+    // If content script not ready, try injecting and retrying
+    try {
+      await chrome.scripting.executeScript({
+        target: { tabId: tab.id },
+        files: ["content/contentScript.js"],
+      });
+      // Retry sending message
+      const message: MessageCopyWithContext = {
+        type: "COPY_WITH_CONTEXT",
+        selectionText: info.selectionText,
+      };
+      await chrome.tabs.sendMessage(tab.id, message);
+    } catch (retryErr) {
+      console.error("Failed to inject and retry:", retryErr);
+    }
+  }
+});
+
+// Handle messages from content scripts and side panel
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === "OPEN_SIDE_PANEL" && sender.tab?.id) {
+    chrome.sidePanel
+      .open({ tabId: sender.tab.id })
+      .then(() => sendResponse({ success: true }))
+      .catch((err) => {
+        console.error("Failed to open side panel:", err);
+        sendResponse({ success: false, error: String(err) });
+      });
+    return true; // Keep message channel open for async response
+  }
+
+  return false;
+});

--- a/packages/extension/src/common/chromeApi.ts
+++ b/packages/extension/src/common/chromeApi.ts
@@ -1,0 +1,17 @@
+/**
+ * Centralized Chrome API access helper
+ * Use this instead of directly accessing chrome/globalThis/window
+ */
+
+export function getChromeAPI(): typeof chrome {
+  if (typeof chrome !== "undefined") {
+    return chrome;
+  }
+  if (typeof globalThis !== "undefined" && "chrome" in globalThis) {
+    return (globalThis as any).chrome;
+  }
+  if (typeof window !== "undefined" && "chrome" in window) {
+    return (window as any).chrome;
+  }
+  throw new Error("Chrome API not available");
+}

--- a/packages/extension/src/common/storage.ts
+++ b/packages/extension/src/common/storage.ts
@@ -1,0 +1,56 @@
+/**
+ * Storage utilities for chrome.storage API
+ */
+
+import { getChromeAPI } from "./chromeApi";
+import type { Capture, Settings } from "./types";
+import { DEFAULT_SETTINGS, DEFAULT_TEMPLATES } from "./types";
+
+export async function getSettings(): Promise<Settings> {
+  const chromeAPI = getChromeAPI();
+  const result = await chromeAPI.storage.local.get("settings");
+  const stored = result.settings || {};
+
+  // Migration: if old promptTemplate exists but no templates array, create one
+  if (stored.promptTemplate && !stored.templates) {
+    stored.templates = [
+      {
+        id: "selection-outline",
+        name: "Create outline from selection",
+        description:
+          "Generate a concise outline from selected text with context",
+        type: "selection",
+        template: stored.promptTemplate,
+      },
+      ...DEFAULT_TEMPLATES.filter((t) => t.id !== "selection-outline"),
+    ];
+  }
+
+  return { ...DEFAULT_SETTINGS, ...stored };
+}
+
+export async function saveSettings(settings: Partial<Settings>): Promise<void> {
+  const chromeAPI = getChromeAPI();
+  const current = await getSettings();
+  await chromeAPI.storage.local.set({
+    settings: { ...current, ...settings },
+  });
+}
+
+export async function saveCapture(capture: Capture): Promise<void> {
+  const chromeAPI = getChromeAPI();
+  await chromeAPI.storage.session.set({
+    [`capture_${capture.tabId}`]: capture,
+  });
+}
+
+export async function getCapture(tabId: number): Promise<Capture | null> {
+  const chromeAPI = getChromeAPI();
+  const result = await chromeAPI.storage.session.get(`capture_${tabId}`);
+  return result[`capture_${tabId}`] || null;
+}
+
+export async function clearCapture(tabId: number): Promise<void> {
+  const chromeAPI = getChromeAPI();
+  await chromeAPI.storage.session.remove(`capture_${tabId}`);
+}

--- a/packages/extension/src/common/template.ts
+++ b/packages/extension/src/common/template.ts
@@ -1,0 +1,16 @@
+/**
+ * Simple mustache-style template renderer
+ * Adapted from MinimalTemplate.ts
+ */
+
+export function renderTemplate(
+  template: string,
+  context: Record<string, unknown>,
+): string {
+  const MUSTACHE = /{{\s*([^}]+?)\s*}}/g;
+  return template.replace(MUSTACHE, (match, key) => {
+    const trimmedKey = key.trim();
+    const value = context[trimmedKey];
+    return value != null ? String(value) : "";
+  });
+}

--- a/packages/extension/src/common/textFragment.ts
+++ b/packages/extension/src/common/textFragment.ts
@@ -1,0 +1,35 @@
+/**
+ * Generate Text Fragment URLs for deep linking
+ * https://web.dev/text-fragments/
+ */
+
+export function toTextFragmentUrl(url: string, selection: string): string {
+  try {
+    // Take first ~120 characters of selection for the fragment
+    // Normalize whitespace for better matching
+    const snippet = selection.slice(0, 120).trim().replace(/\s+/g, " ");
+    if (!snippet) return url;
+
+    // Encode the snippet
+    const encoded = encodeURIComponent(snippet);
+
+    // Parse URL and add text fragment
+    const urlObj = new URL(url);
+
+    // Preserve existing hash if present
+    // Text fragments should be appended after existing hash with :~:
+    const existingHash = urlObj.hash.slice(1); // Remove leading #
+    if (existingHash && !existingHash.includes(":~:")) {
+      // Has existing hash but no text fragment yet
+      urlObj.hash = `${existingHash}:~:text=${encoded}`;
+    } else {
+      // No existing hash, or already has a text fragment
+      urlObj.hash = `:~:text=${encoded}`;
+    }
+
+    return urlObj.toString();
+  } catch {
+    // If URL parsing fails, return original URL
+    return url;
+  }
+}

--- a/packages/extension/src/common/types.ts
+++ b/packages/extension/src/common/types.ts
@@ -1,0 +1,146 @@
+/**
+ * Core types for the Copy with Context extension
+ */
+
+export interface Capture {
+  id: string;
+  tabId: number;
+  url: string;
+  pageTitle: string;
+  fragmentUrl?: string;
+  selection: string;
+  context: string;
+  createdAt: number;
+}
+
+export interface ContextPayload {
+  pageTitle: string;
+  url: string;
+  fragmentUrl?: string;
+  selection: string;
+  beforeContext: string;
+  afterContext: string;
+  prompt?: string; // Store the actual prompt for consistency
+}
+
+export interface MessageCopyWithContext {
+  type: "COPY_WITH_CONTEXT";
+  selectionText?: string; // Selection text from context menu
+}
+
+export interface MessageShowOverlay {
+  type: "SHOW_OVERLAY";
+  outline: string;
+  captureId?: string;
+}
+
+export interface MessageOpenSidePanel {
+  type: "OPEN_SIDE_PANEL";
+}
+
+export type ExtensionMessage =
+  | MessageCopyWithContext
+  | MessageShowOverlay
+  | MessageOpenSidePanel;
+
+export type TemplateType = "selection" | "article";
+
+export interface Template {
+  id: string;
+  name: string;
+  description: string;
+  type: TemplateType;
+  template: string;
+}
+
+export interface Settings {
+  wordLimit: number;
+  openChatGPTAfterCopy: boolean;
+  templates: Template[];
+  // Legacy field for backward compatibility
+  promptTemplate?: string;
+}
+
+export const DEFAULT_TEMPLATES: Template[] = [
+  {
+    id: "selection-outline",
+    name: "Create outline from selection",
+    description: "Generate a concise outline from selected text with context",
+    type: "selection",
+    template: `You are a writing assistant. Given an excerpt and its immediate context from a web page, produce a concise outline (3–8 bullets) of the section/chapter likely covered by this excerpt.
+
+Page title: {{pageTitle}}
+URL: {{url}}
+Deep link (if available): {{fragmentUrl}}
+
+Selection:
+"""
+{{selection}}
+"""
+
+Surrounding context:
+"""
+{{context}}
+"""
+
+Return only the outline bullets plus a one-line verdict: "Worth reading now?" = Yes/No + a 10-word reason.`,
+  },
+  {
+    id: "selection-summary",
+    name: "Summarize selection",
+    description: "Create a brief summary of the selected text",
+    type: "selection",
+    template: `Summarize the following text excerpt in 2-3 sentences.
+
+Page title: {{pageTitle}}
+URL: {{url}}
+
+Selection:
+"""
+{{selection}}
+"""
+
+Context:
+"""
+{{context}}
+"""`,
+  },
+  {
+    id: "article-outline",
+    name: "Create outline from article",
+    description: "Generate a comprehensive outline from the full article",
+    type: "article",
+    template: `You are a writing assistant. Create a comprehensive outline (5-12 bullets) of the main points in this article.
+
+Page title: {{pageTitle}}
+URL: {{url}}
+
+Article content:
+"""
+{{selection}}
+"""
+
+Return the outline plus a one-line verdict: "Worth reading?" = Yes/No + a 10-word reason.`,
+  },
+  {
+    id: "article-summary",
+    name: "Summarize article",
+    description: "Create a detailed summary of the full article",
+    type: "article",
+    template: `Summarize this article in 3-5 paragraphs, covering the main points and key takeaways.
+
+Page title: {{pageTitle}}
+URL: {{url}}
+
+Article content:
+"""
+{{selection}}
+"""`,
+  },
+];
+
+export const DEFAULT_SETTINGS: Settings = {
+  wordLimit: 400,
+  openChatGPTAfterCopy: false,
+  templates: DEFAULT_TEMPLATES,
+};

--- a/packages/extension/src/content/commandMenu.ts
+++ b/packages/extension/src/content/commandMenu.ts
@@ -1,0 +1,734 @@
+/**
+ * Command menu UI and keyboard shortcut handling
+ * Shows a centered overlay with available commands when user presses cmd-k/ctrl-k
+ */
+
+import { Readability } from "@mozilla/readability";
+
+let menuRoot: ShadowRoot | null = null;
+let menuHost: HTMLElement | null = null;
+
+interface CommandOption {
+  id: string;
+  label: string;
+  description?: string;
+  icon?: string;
+  shortcut?: string;
+  category: "selection" | "article";
+  action: () => void | Promise<void>;
+}
+
+function ensureMenuRoot(): ShadowRoot {
+  if (menuRoot) return menuRoot;
+
+  menuHost = document.createElement("cwc-command-menu");
+  Object.assign(menuHost.style, {
+    all: "initial",
+    position: "fixed",
+    top: "0",
+    left: "0",
+    right: "0",
+    bottom: "0",
+    zIndex: "2147483647",
+    pointerEvents: "none",
+  });
+
+  document.documentElement.appendChild(menuHost);
+  menuRoot = menuHost.attachShadow({ mode: "open" });
+
+  const style = document.createElement("style");
+  style.textContent = `
+    * {
+      box-sizing: border-box;
+    }
+
+    @keyframes fadeIn {
+      from {
+        opacity: 0;
+      }
+      to {
+        opacity: 1;
+      }
+    }
+
+    @keyframes scaleIn {
+      from {
+        opacity: 0;
+        transform: scale(0.96) translateY(-16px);
+      }
+      to {
+        opacity: 1;
+        transform: scale(1) translateY(0);
+      }
+    }
+
+    @keyframes shimmer {
+      0% {
+        background-position: -468px 0;
+      }
+      100% {
+        background-position: 468px 0;
+      }
+    }
+
+    .backdrop {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(0, 0, 0, 0.6);
+      backdrop-filter: blur(8px);
+      animation: fadeIn 0.15s ease-out;
+      display: flex;
+      align-items: flex-start;
+      justify-content: center;
+      padding-top: 120px;
+      pointer-events: auto;
+    }
+
+    .command-menu {
+      background: linear-gradient(to bottom, #2a2d2e 0%, #252526 100%);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      border-radius: 12px;
+      box-shadow:
+        0 0 0 1px rgba(0, 0, 0, 0.05),
+        0 24px 48px rgba(0, 0, 0, 0.7),
+        0 8px 16px rgba(0, 0, 0, 0.4);
+      width: 640px;
+      max-width: 90vw;
+      max-height: 480px;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      animation: scaleIn 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+      pointer-events: auto;
+    }
+
+    .search-container {
+      position: relative;
+      padding: 4px;
+    }
+
+    .search-icon {
+      position: absolute;
+      left: 20px;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 18px;
+      height: 18px;
+      color: #6c6c6c;
+      pointer-events: none;
+    }
+
+    .search-input {
+      padding: 16px 20px 16px 48px;
+      border: none;
+      font-size: 15px;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+      font-weight: 400;
+      outline: none;
+      background: rgba(255, 255, 255, 0.05);
+      color: #e4e4e4;
+      border-radius: 8px;
+      width: 100%;
+      transition: background 0.15s ease;
+    }
+
+    .search-input:focus {
+      background: rgba(255, 255, 255, 0.08);
+    }
+
+    .search-input::placeholder {
+      color: #6c6c6c;
+      font-weight: 400;
+    }
+
+    .commands-container {
+      display: flex;
+      flex-direction: column;
+      overflow-y: auto;
+      max-height: 400px;
+      padding: 8px;
+    }
+
+    .category-header {
+      padding: 8px 16px 4px 16px;
+      font-size: 11px;
+      font-weight: 600;
+      color: #858585;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      margin-top: 4px;
+    }
+
+    .category-header:first-child {
+      margin-top: 0;
+    }
+
+    .command-item {
+      padding: 10px 12px;
+      cursor: pointer;
+      border: none;
+      background: transparent;
+      width: 100%;
+      text-align: left;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+      transition: all 0.12s cubic-bezier(0.4, 0, 0.2, 1);
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      border-radius: 6px;
+      margin: 1px 0;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .command-item::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 0;
+      bottom: 0;
+      width: 3px;
+      background: linear-gradient(to bottom, #4c9aff, #0052cc);
+      opacity: 0;
+      transition: opacity 0.12s ease;
+    }
+
+    .command-item:hover {
+      background: rgba(255, 255, 255, 0.06);
+      transform: translateX(2px);
+    }
+
+    .command-item.selected {
+      background: linear-gradient(90deg, rgba(76, 154, 255, 0.16) 0%, rgba(76, 154, 255, 0.08) 100%);
+      box-shadow: inset 0 0 0 1px rgba(76, 154, 255, 0.3);
+    }
+
+    .command-item.selected::before {
+      opacity: 1;
+    }
+
+    .command-item-icon {
+      width: 32px;
+      height: 32px;
+      flex-shrink: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 18px;
+      background: rgba(255, 255, 255, 0.06);
+      border-radius: 6px;
+      transition: all 0.12s ease;
+    }
+
+    .command-item:hover .command-item-icon,
+    .command-item.selected .command-item-icon {
+      background: rgba(76, 154, 255, 0.15);
+      transform: scale(1.05);
+    }
+
+    .command-item-content {
+      flex: 1;
+      min-width: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+
+    .command-item-label {
+      font-size: 14px;
+      font-weight: 500;
+      color: #e4e4e4;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      transition: color 0.12s ease;
+    }
+
+    .command-item.selected .command-item-label {
+      color: #ffffff;
+    }
+
+    .command-item-description {
+      font-size: 12px;
+      color: #9a9a9a;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      line-height: 1.3;
+    }
+
+    .command-item-shortcut {
+      flex-shrink: 0;
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      margin-left: 8px;
+    }
+
+    .shortcut-key {
+      padding: 3px 6px;
+      background: rgba(255, 255, 255, 0.08);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      border-radius: 4px;
+      font-size: 11px;
+      font-weight: 600;
+      color: #b0b0b0;
+      font-family: 'SF Mono', 'Monaco', 'Consolas', monospace;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+      transition: all 0.12s ease;
+    }
+
+    .command-item.selected .shortcut-key {
+      background: rgba(76, 154, 255, 0.2);
+      border-color: rgba(76, 154, 255, 0.3);
+      color: #ffffff;
+    }
+
+    .no-results {
+      padding: 48px 20px;
+      text-align: center;
+      color: #6c6c6c;
+      font-size: 14px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .no-results-icon {
+      font-size: 32px;
+      opacity: 0.5;
+    }
+
+    .footer {
+      padding: 12px 16px;
+      border-top: 1px solid rgba(255, 255, 255, 0.06);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      font-size: 11px;
+      color: #6c6c6c;
+      background: rgba(0, 0, 0, 0.2);
+    }
+
+    .footer-shortcuts {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+    }
+
+    .footer-shortcut {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .footer-key {
+      padding: 2px 5px;
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 3px;
+      font-size: 10px;
+      font-weight: 600;
+      color: #858585;
+      font-family: 'SF Mono', 'Monaco', 'Consolas', monospace;
+    }
+
+    .highlight {
+      background: rgba(255, 200, 0, 0.3);
+      color: #ffd700;
+      font-weight: 600;
+      padding: 0 2px;
+      border-radius: 2px;
+    }
+
+    /* Custom scrollbar */
+    .commands-container::-webkit-scrollbar {
+      width: 8px;
+    }
+
+    .commands-container::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    .commands-container::-webkit-scrollbar-thumb {
+      background: rgba(255, 255, 255, 0.15);
+      border-radius: 4px;
+      border: 2px solid transparent;
+      background-clip: padding-box;
+    }
+
+    .commands-container::-webkit-scrollbar-thumb:hover {
+      background: rgba(255, 255, 255, 0.25);
+      background-clip: padding-box;
+    }
+  `;
+  menuRoot.appendChild(style);
+
+  return menuRoot;
+}
+
+export function removeCommandMenu(): void {
+  if (menuHost) {
+    menuHost.remove();
+    menuHost = null;
+    menuRoot = null;
+  }
+}
+
+function highlightText(text: string, query: string): string {
+  if (!query) return text;
+  const regex = new RegExp(
+    `(${query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})`,
+    "gi",
+  );
+  return text.replace(regex, '<span class="highlight">$1</span>');
+}
+
+export function showCommandMenu(options: CommandOption[]): void {
+  const root = ensureMenuRoot();
+
+  // Create backdrop for click-outside-to-close
+  const backdrop = document.createElement("div");
+  backdrop.className = "backdrop";
+  backdrop.addEventListener("click", (e) => {
+    // Only close if clicking the backdrop itself, not children
+    if (e.target === backdrop) {
+      removeCommandMenu();
+    }
+  });
+
+  // Global escape key handler
+  const handleEscape = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      e.stopPropagation();
+      removeCommandMenu();
+    }
+  };
+  backdrop.addEventListener("keydown", handleEscape);
+
+  const container = document.createElement("div");
+  container.className = "command-menu";
+
+  // Search container with icon
+  const searchContainer = document.createElement("div");
+  searchContainer.className = "search-container";
+
+  const searchIcon = document.createElement("div");
+  searchIcon.className = "search-icon";
+  searchIcon.innerHTML = `
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <circle cx="11" cy="11" r="8"></circle>
+      <path d="m21 21-4.35-4.35"></path>
+    </svg>
+  `;
+  searchContainer.appendChild(searchIcon);
+
+  const searchInput = document.createElement("input");
+  searchInput.className = "search-input";
+  searchInput.type = "text";
+  searchInput.placeholder = "Search commands...";
+  searchContainer.appendChild(searchInput);
+
+  container.appendChild(searchContainer);
+
+  const commandsContainer = document.createElement("div");
+  commandsContainer.className = "commands-container";
+  container.appendChild(commandsContainer);
+
+  // Footer with shortcuts
+  const footer = document.createElement("div");
+  footer.className = "footer";
+  footer.innerHTML = `
+    <div class="footer-shortcuts">
+      <div class="footer-shortcut">
+        <span class="footer-key">↑↓</span>
+        <span>Navigate</span>
+      </div>
+      <div class="footer-shortcut">
+        <span class="footer-key">↵</span>
+        <span>Select</span>
+      </div>
+      <div class="footer-shortcut">
+        <span class="footer-key">Esc</span>
+        <span>Close</span>
+      </div>
+    </div>
+    <div>${options.length} command${options.length === 1 ? "" : "s"}</div>
+  `;
+  container.appendChild(footer);
+
+  let selectedIndex = 0;
+  let currentQuery = "";
+
+  function renderCommands(filteredOptions: CommandOption[]) {
+    commandsContainer.innerHTML = "";
+
+    if (filteredOptions.length === 0) {
+      const noResults = document.createElement("div");
+      noResults.className = "no-results";
+      noResults.innerHTML = `
+        <div class="no-results-icon">🔍</div>
+        <div>No commands found</div>
+      `;
+      commandsContainer.appendChild(noResults);
+      return;
+    }
+
+    // Group by category
+    const selectionCommands = filteredOptions.filter(
+      (o) => o.category === "selection",
+    );
+    const articleCommands = filteredOptions.filter(
+      (o) => o.category === "article",
+    );
+
+    let globalIndex = 0;
+
+    // Render selection commands
+    if (selectionCommands.length > 0) {
+      const categoryHeader = document.createElement("div");
+      categoryHeader.className = "category-header";
+      categoryHeader.textContent = "Selection Commands";
+      commandsContainer.appendChild(categoryHeader);
+
+      for (const option of selectionCommands) {
+        const item = createCommandItem(option, globalIndex === selectedIndex);
+        commandsContainer.appendChild(item);
+        globalIndex++;
+      }
+    }
+
+    // Render article commands
+    if (articleCommands.length > 0) {
+      const categoryHeader = document.createElement("div");
+      categoryHeader.className = "category-header";
+      categoryHeader.textContent = "Article Commands";
+      commandsContainer.appendChild(categoryHeader);
+
+      for (const option of articleCommands) {
+        const item = createCommandItem(option, globalIndex === selectedIndex);
+        commandsContainer.appendChild(item);
+        globalIndex++;
+      }
+    }
+  }
+
+  function createCommandItem(
+    option: CommandOption,
+    isSelected: boolean,
+  ): HTMLElement {
+    const item = document.createElement("button");
+    item.className = `command-item${isSelected ? " selected" : ""}`;
+
+    // Icon
+    if (option.icon) {
+      const icon = document.createElement("div");
+      icon.className = "command-item-icon";
+      icon.textContent = option.icon;
+      item.appendChild(icon);
+    }
+
+    // Content
+    const content = document.createElement("div");
+    content.className = "command-item-content";
+
+    const label = document.createElement("div");
+    label.className = "command-item-label";
+    label.innerHTML = highlightText(option.label, currentQuery);
+    content.appendChild(label);
+
+    if (option.description) {
+      const description = document.createElement("div");
+      description.className = "command-item-description";
+      description.innerHTML = highlightText(option.description, currentQuery);
+      content.appendChild(description);
+    }
+
+    item.appendChild(content);
+
+    // Shortcut
+    if (option.shortcut) {
+      const shortcutContainer = document.createElement("div");
+      shortcutContainer.className = "command-item-shortcut";
+
+      const shortcutKey = document.createElement("span");
+      shortcutKey.className = "shortcut-key";
+      shortcutKey.textContent = option.shortcut;
+      shortcutContainer.appendChild(shortcutKey);
+
+      item.appendChild(shortcutContainer);
+    }
+
+    item.addEventListener("click", async () => {
+      await option.action();
+      removeCommandMenu();
+    });
+
+    return item;
+  }
+
+  let filteredOptions = options;
+  renderCommands(filteredOptions);
+
+  // Search functionality
+  searchInput.addEventListener("input", () => {
+    currentQuery = searchInput.value;
+    const query = currentQuery.toLowerCase();
+    filteredOptions = options.filter(
+      (opt) =>
+        opt.label.toLowerCase().includes(query) ||
+        opt.description?.toLowerCase().includes(query),
+    );
+    selectedIndex = 0;
+    renderCommands(filteredOptions);
+  });
+
+  // Keyboard navigation
+  searchInput.addEventListener("keydown", async (e) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      removeCommandMenu();
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      selectedIndex = Math.min(selectedIndex + 1, filteredOptions.length - 1);
+      renderCommands(filteredOptions);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      selectedIndex = Math.max(selectedIndex - 1, 0);
+      renderCommands(filteredOptions);
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const selected = filteredOptions[selectedIndex];
+      if (selected) {
+        await selected.action();
+        removeCommandMenu();
+      }
+    }
+  });
+
+  // Append container to backdrop
+  backdrop.appendChild(container);
+
+  // Clear previous content but preserve styles
+  const style = root.querySelector("style");
+  root.innerHTML = "";
+  if (style) {
+    root.appendChild(style);
+  }
+  root.appendChild(backdrop);
+
+  // Auto-focus the search input
+  setTimeout(() => searchInput.focus(), 50);
+}
+
+/**
+ * Extract article content using Readability
+ */
+export function extractArticleContent(): {
+  title: string;
+  content: string;
+  textContent: string;
+} | null {
+  try {
+    // Clone the document to avoid modifying the original
+    const documentClone = document.cloneNode(true) as Document;
+    const reader = new Readability(documentClone);
+    const article = reader.parse();
+
+    if (!article) {
+      return null;
+    }
+
+    return {
+      title: article.title || "",
+      content: article.content || "",
+      textContent: (article.textContent || "").trim(),
+    };
+  } catch (err) {
+    console.error("Failed to extract article content:", err);
+    return null;
+  }
+}
+
+/**
+ * Check if user has selected text
+ */
+export function hasTextSelection(): boolean {
+  const selection = window.getSelection();
+  return !!(selection && selection.toString().trim().length > 0);
+}
+
+/**
+ * Initialize keyboard shortcut listener
+ */
+export function initCommandMenuShortcut(
+  onCopyWithTemplate: (
+    templateId: string,
+    type: "selection" | "article",
+  ) => void | Promise<void>,
+): () => void {
+  const handleKeyDown = async (e: KeyboardEvent) => {
+    // Check for cmd-k (Mac) or ctrl-k (Windows/Linux)
+    if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+      e.preventDefault();
+      e.stopPropagation();
+
+      // Dynamically import to avoid circular dependency
+      const { getSettings } = await import("../common/storage");
+      const settings = await getSettings();
+
+      const options: CommandOption[] = [];
+      const hasSelection = hasTextSelection();
+
+      // Add selection templates if user has selected text
+      if (hasSelection) {
+        const selectionTemplates = settings.templates.filter(
+          (t) => t.type === "selection",
+        );
+        let shortcutIndex = 1;
+        for (const template of selectionTemplates) {
+          options.push({
+            id: template.id,
+            label: template.name,
+            description: template.description,
+            icon: "📝",
+            category: "selection",
+            action: () => onCopyWithTemplate(template.id, "selection"),
+          });
+          shortcutIndex++;
+        }
+      }
+
+      // Add article templates
+      const articleTemplates = settings.templates.filter(
+        (t) => t.type === "article",
+      );
+      let shortcutIndex = 1;
+      for (const template of articleTemplates) {
+        options.push({
+          id: template.id,
+          label: template.name,
+          description: template.description,
+          icon: "📄",
+          category: "article",
+          action: () => onCopyWithTemplate(template.id, "article"),
+        });
+        shortcutIndex++;
+      }
+
+      showCommandMenu(options);
+    }
+  };
+
+  document.addEventListener("keydown", handleKeyDown);
+
+  // Return cleanup function
+  return () => {
+    document.removeEventListener("keydown", handleKeyDown);
+  };
+}

--- a/packages/extension/src/content/commandMenu.ts
+++ b/packages/extension/src/content/commandMenu.ts
@@ -647,7 +647,9 @@ export function extractArticleContent(): {
     return {
       title: article.title || "",
       content: article.content || "",
-      textContent: (article.textContent || "").trim(),
+      textContent: (article.textContent || "")
+        .replace(/\n{3,}/g, "\n\n") // collapse 3+ newlines to 2
+        .trim(),
     };
   } catch (err) {
     console.error("Failed to extract article content:", err);

--- a/packages/extension/src/content/contentScript.css
+++ b/packages/extension/src/content/contentScript.css
@@ -1,0 +1,10 @@
+/**
+ * Minimal content script styles
+ * Most styles are in Shadow DOM (see overlay.ts)
+ */
+
+/* Reset for custom element host */
+cwc-overlay {
+  all: initial;
+  display: block;
+}

--- a/packages/extension/src/content/contentScript.ts
+++ b/packages/extension/src/content/contentScript.ts
@@ -1,0 +1,273 @@
+/**
+ * Main content script for Copy with Context extension
+ * Handles messages from background script and coordinates context extraction
+ */
+
+import "./contentScript.css";
+import { getChromeAPI } from "../common/chromeApi";
+import type { ExtensionMessage } from "../common/types";
+import { extractArticleContent, initCommandMenuShortcut } from "./commandMenu";
+import { showOverlay, showToast } from "./overlay";
+import { buildContextPayload } from "./smartContext";
+
+// Open ChatGPT in a new tab
+function openChatGPT(): void {
+  window.open("https://chat.openai.com/", "_blank");
+}
+
+// Open side panel
+async function openSidePanel(): Promise<void> {
+  try {
+    const chromeAPI = getChromeAPI();
+    await chromeAPI.runtime.sendMessage({ type: "OPEN_SIDE_PANEL" });
+  } catch (err) {
+    console.error("Failed to open side panel:", err);
+  }
+}
+
+// Main handler for copying with context
+async function copyWithContext(
+  preSelectedText?: string,
+  templateId?: string,
+): Promise<void> {
+  console.log(
+    "copyWithContext called with preSelectedText:",
+    preSelectedText,
+    "templateId:",
+    templateId,
+  );
+
+  // If we have pre-selected text from context menu but no current selection,
+  // we need to build context differently
+  const selection = window.getSelection();
+  const hasCurrentSelection =
+    selection && selection.toString().trim().length > 0;
+
+  console.log("Current selection:", selection?.toString());
+  console.log("Has current selection:", hasCurrentSelection);
+
+  // Build context payload using current selection or fallback
+  const built = await buildContextPayload();
+
+  if (!built) {
+    // If no selection context could be built, try with just the pre-selected text
+    if (preSelectedText) {
+      console.log("No context built, using pre-selected text only");
+      const simplePayload = {
+        pageTitle: document.title,
+        url: location.href,
+        selection: preSelectedText,
+        beforeContext: "",
+        afterContext: "",
+        fragmentUrl: undefined,
+      };
+
+      const settings = await (await import("../common/storage")).getSettings();
+
+      // Find the template to use
+      const template = templateId
+        ? settings.templates.find((t) => t.id === templateId)
+        : settings.templates.find((t) => t.type === "selection");
+
+      if (!template) {
+        showToast("Template not found");
+        return;
+      }
+
+      const prompt = (await import("../common/template")).renderTemplate(
+        template.template,
+        {
+          pageTitle: simplePayload.pageTitle,
+          url: simplePayload.url,
+          fragmentUrl: "",
+          selection: simplePayload.selection,
+          context: simplePayload.selection,
+        },
+      );
+
+      await copyToClipboardAndNotify(prompt, simplePayload);
+      return;
+    }
+
+    showToast("No selection found. Please select some text and try again.");
+    return;
+  }
+
+  // If a specific template is provided, use it
+  if (templateId) {
+    const settings = await (await import("../common/storage")).getSettings();
+    const template = settings.templates.find((t) => t.id === templateId);
+
+    if (!template) {
+      showToast("Template not found");
+      return;
+    }
+
+    const combinedContext = [
+      built.payload.beforeContext,
+      built.payload.selection,
+      built.payload.afterContext,
+    ]
+      .filter(Boolean)
+      .join("\n\n");
+
+    const prompt = (await import("../common/template")).renderTemplate(
+      template.template,
+      {
+        pageTitle: built.payload.pageTitle,
+        url: built.payload.url,
+        fragmentUrl: built.payload.fragmentUrl || "",
+        selection: built.payload.selection,
+        context: combinedContext,
+      },
+    );
+
+    await copyToClipboardAndNotify(prompt, built.payload);
+    return;
+  }
+
+  await copyToClipboardAndNotify(built.prompt, built.payload);
+}
+
+async function copyToClipboardAndNotify(
+  prompt: string,
+  payload: {
+    url: string;
+    pageTitle: string;
+    fragmentUrl?: string;
+    selection: string;
+    beforeContext: string;
+    afterContext: string;
+  },
+): Promise<void> {
+  try {
+    console.log("Copying to clipboard:", prompt.substring(0, 100) + "...");
+
+    // Copy to clipboard
+    await navigator.clipboard.writeText(prompt);
+    console.log("Clipboard write successful");
+
+    // Save to session storage for side panel to retrieve
+    // Include the prompt for consistency between copy and side panel
+    const chromeAPI = getChromeAPI();
+    await chromeAPI.storage.session.set({
+      lastCapture: {
+        ...payload,
+        prompt, // Store the actual prompt that was copied
+      },
+    });
+    console.log("Capture saved to session storage");
+
+    // Show toast with actions
+    showToast("Copied ChatGPT template!", [
+      {
+        label: "Open ChatGPT",
+        onClick: openChatGPT,
+      },
+      {
+        label: "Side Panel",
+        onClick: openSidePanel,
+        secondary: true,
+      },
+    ]);
+  } catch (err) {
+    console.error("Failed to copy with context:", err);
+    showToast(
+      `Failed to copy: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+// Copy entire article content using Readability
+async function copyArticleContent(templateId?: string): Promise<void> {
+  console.log("copyArticleContent called with templateId:", templateId);
+
+  const article = extractArticleContent();
+
+  if (!article) {
+    showToast(
+      "Could not extract article content. This page may not have a main article.",
+    );
+    return;
+  }
+
+  const settings = await (await import("../common/storage")).getSettings();
+
+  // Find the template to use
+  const template = templateId
+    ? settings.templates.find((t) => t.id === templateId)
+    : settings.templates.find((t) => t.type === "article");
+
+  if (!template) {
+    showToast("Template not found");
+    return;
+  }
+
+  // Create a payload with the article content
+  const payload = {
+    pageTitle: article.title || document.title,
+    url: location.href,
+    fragmentUrl: undefined,
+    selection: article.textContent.trim(),
+    beforeContext: "",
+    afterContext: "",
+  };
+
+  // Render template with article content
+  const prompt = (await import("../common/template")).renderTemplate(
+    template.template,
+    {
+      pageTitle: payload.pageTitle,
+      url: payload.url,
+      fragmentUrl: "",
+      selection: payload.selection,
+      context: payload.selection,
+    },
+  );
+
+  await copyToClipboardAndNotify(prompt, payload);
+}
+
+// Handle messages from background script
+getChromeAPI().runtime.onMessage.addListener(
+  (
+    message: ExtensionMessage,
+    sender: chrome.runtime.MessageSender,
+    sendResponse: (response: any) => void,
+  ) => {
+    console.log("Content script received message:", message);
+
+    if (message.type === "COPY_WITH_CONTEXT") {
+      copyWithContext(message.selectionText)
+        .then(() => {
+          console.log("Copy with context completed");
+          sendResponse({ success: true });
+        })
+        .catch((err) => {
+          console.error("Copy with context failed:", err);
+          sendResponse({ success: false, error: String(err) });
+        });
+      return true; // Keep channel open for async response
+    }
+
+    if (message.type === "SHOW_OVERLAY") {
+      showOverlay(message.outline, message.captureId);
+      sendResponse({ success: true });
+      return false;
+    }
+
+    return false;
+  },
+);
+
+// Initialize command menu keyboard shortcut (cmd-k / ctrl-k)
+initCommandMenuShortcut(async (templateId, type) => {
+  if (type === "selection") {
+    await copyWithContext(undefined, templateId);
+  } else if (type === "article") {
+    await copyArticleContent(templateId);
+  }
+});
+
+// Log when content script loads
+console.log("Copy with Context content script loaded");

--- a/packages/extension/src/content/contentScript.ts
+++ b/packages/extension/src/content/contentScript.ts
@@ -208,7 +208,7 @@ async function copyArticleContent(templateId?: string): Promise<void> {
     pageTitle: article.title || document.title,
     url: location.href,
     fragmentUrl: undefined,
-    selection: article.textContent.trim(),
+    selection: article.textContent, // already processed by extractArticleContent
     beforeContext: "",
     afterContext: "",
   };

--- a/packages/extension/src/content/overlay.ts
+++ b/packages/extension/src/content/overlay.ts
@@ -1,0 +1,285 @@
+/**
+ * Overlay UI management using Shadow DOM
+ */
+
+let root: ShadowRoot | null = null;
+let host: HTMLElement | null = null;
+
+export function ensureOverlayRoot(): ShadowRoot {
+  if (root) return root;
+
+  host = document.createElement("cwc-overlay");
+  Object.assign(host.style, {
+    all: "initial",
+    position: "fixed",
+    right: "16px",
+    bottom: "16px",
+    zIndex: "2147483647",
+    fontFamily: "system-ui, -apple-system, sans-serif",
+  });
+
+  document.documentElement.appendChild(host);
+  root = host.attachShadow({ mode: "open" });
+
+  const container = document.createElement("div");
+  container.id = "cwc-container";
+  root.appendChild(container);
+
+  // Add minimal styles inside shadow DOM
+  const style = document.createElement("style");
+  style.textContent = `
+    #cwc-container {
+      font-family: system-ui, -apple-system, sans-serif;
+      font-size: 14px;
+      line-height: 1.5;
+    }
+
+    .cwc-toast {
+      background: #1a1a1a;
+      color: white;
+      padding: 12px 16px;
+      border-radius: 8px;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      max-width: 400px;
+    }
+
+    .cwc-toast-text {
+      flex: 1;
+    }
+
+    .cwc-toast-actions {
+      display: flex;
+      gap: 8px;
+    }
+
+    .cwc-toast-button {
+      background: #3b82f6;
+      color: white;
+      border: none;
+      padding: 6px 12px;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 13px;
+      white-space: nowrap;
+    }
+
+    .cwc-toast-button:hover {
+      background: #2563eb;
+    }
+
+    .cwc-toast-button-secondary {
+      background: #4b5563;
+    }
+
+    .cwc-toast-button-secondary:hover {
+      background: #374151;
+    }
+
+    .cwc-card {
+      background: white;
+      border: 1px solid #e5e7eb;
+      border-radius: 12px;
+      box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15);
+      max-width: 500px;
+      max-height: 600px;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    .cwc-card-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 16px;
+      border-bottom: 1px solid #e5e7eb;
+      background: #f9fafb;
+    }
+
+    .cwc-card-title {
+      font-weight: 600;
+      font-size: 16px;
+      color: #1a1a1a;
+      margin: 0;
+    }
+
+    .cwc-card-close {
+      background: transparent;
+      border: none;
+      font-size: 24px;
+      color: #6b7280;
+      cursor: pointer;
+      padding: 0;
+      width: 28px;
+      height: 28px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 4px;
+    }
+
+    .cwc-card-close:hover {
+      background: #e5e7eb;
+      color: #1a1a1a;
+    }
+
+    .cwc-card-body {
+      padding: 16px;
+      overflow-y: auto;
+      flex: 1;
+    }
+
+    .cwc-card-body pre {
+      margin: 0;
+      white-space: pre-wrap;
+      word-wrap: break-word;
+      font-family: ui-monospace, monospace;
+      font-size: 13px;
+      color: #374151;
+      line-height: 1.6;
+    }
+
+    .cwc-card-actions {
+      padding: 12px 16px;
+      border-top: 1px solid #e5e7eb;
+      display: flex;
+      gap: 8px;
+      justify-content: flex-end;
+    }
+
+    .cwc-card-button {
+      background: #3b82f6;
+      color: white;
+      border: none;
+      padding: 8px 16px;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 14px;
+      font-weight: 500;
+    }
+
+    .cwc-card-button:hover {
+      background: #2563eb;
+    }
+  `;
+  root.appendChild(style);
+
+  return root;
+}
+
+export function removeOverlay(): void {
+  if (host) {
+    host.remove();
+    host = null;
+    root = null;
+  }
+}
+
+export function showToast(
+  text: string,
+  actions?: Array<{ label: string; onClick: () => void; secondary?: boolean }>,
+): void {
+  const r = ensureOverlayRoot();
+  const container = r.getElementById("cwc-container");
+  if (!container) return;
+
+  const toast = document.createElement("div");
+  toast.className = "cwc-toast";
+
+  const textEl = document.createElement("div");
+  textEl.className = "cwc-toast-text";
+  textEl.textContent = text;
+  toast.appendChild(textEl);
+
+  if (actions && actions.length > 0) {
+    const actionsEl = document.createElement("div");
+    actionsEl.className = "cwc-toast-actions";
+
+    for (const action of actions) {
+      const button = document.createElement("button");
+      button.className = action.secondary
+        ? "cwc-toast-button cwc-toast-button-secondary"
+        : "cwc-toast-button";
+      button.textContent = action.label;
+      button.addEventListener("click", () => {
+        action.onClick();
+        removeOverlay();
+      });
+      actionsEl.appendChild(button);
+    }
+
+    toast.appendChild(actionsEl);
+  }
+
+  container.innerHTML = "";
+  container.appendChild(toast);
+
+  // Auto-hide after 10 seconds if no actions
+  if (!actions || actions.length === 0) {
+    setTimeout(() => {
+      if (container.firstChild === toast) {
+        removeOverlay();
+      }
+    }, 10000);
+  }
+}
+
+export function showOverlay(outline: string, captureId?: string): void {
+  const r = ensureOverlayRoot();
+  const container = r.getElementById("cwc-container");
+  if (!container) return;
+
+  const card = document.createElement("div");
+  card.className = "cwc-card";
+
+  // Header
+  const header = document.createElement("div");
+  header.className = "cwc-card-header";
+
+  const title = document.createElement("h3");
+  title.className = "cwc-card-title";
+  title.textContent = "Outline";
+  header.appendChild(title);
+
+  const closeBtn = document.createElement("button");
+  closeBtn.className = "cwc-card-close";
+  closeBtn.innerHTML = "×";
+  closeBtn.addEventListener("click", () => removeOverlay());
+  header.appendChild(closeBtn);
+
+  card.appendChild(header);
+
+  // Body
+  const body = document.createElement("div");
+  body.className = "cwc-card-body";
+
+  const pre = document.createElement("pre");
+  pre.textContent = outline.trim();
+  body.appendChild(pre);
+
+  card.appendChild(body);
+
+  // Actions
+  const actions = document.createElement("div");
+  actions.className = "cwc-card-actions";
+
+  const copyBtn = document.createElement("button");
+  copyBtn.className = "cwc-card-button";
+  copyBtn.textContent = "Copy outline";
+  copyBtn.addEventListener("click", async () => {
+    await navigator.clipboard.writeText(outline);
+    copyBtn.textContent = "Copied!";
+    setTimeout(() => {
+      copyBtn.textContent = "Copy outline";
+    }, 2000);
+  });
+  actions.appendChild(copyBtn);
+
+  card.appendChild(actions);
+
+  container.innerHTML = "";
+  container.appendChild(card);
+}

--- a/packages/extension/src/content/selection.ts
+++ b/packages/extension/src/content/selection.ts
@@ -1,0 +1,168 @@
+/**
+ * Selection context extraction utilities
+ * Adapted from packages/reader/src/utils/selectionUtils.ts
+ */
+
+export interface SelectionContext {
+  beforeContext: string;
+  selectedText: string;
+  afterContext: string;
+}
+
+/**
+ * Extracts text context around a selection within a container element.
+ *
+ * This class creates ranges from the container root to the selection start/end,
+ * clones the DOM fragments, strips non-content elements (scripts, styles, etc.),
+ * and normalizes whitespace to produce clean before/after context strings.
+ *
+ * The word limit is split roughly evenly between before and after context,
+ * with rebalancing if one side has fewer words available than allocated.
+ */
+class SelectionContextExtractor {
+  private readonly selection: Selection;
+  private readonly baseRange: Range;
+  private readonly root: Element;
+  private readonly wordLimit: number;
+
+  constructor(selection: Selection, container?: Element, wordLimit = 400) {
+    if (!selection || selection.rangeCount === 0) {
+      throw new Error("getSelectionContext: no selection range found");
+    }
+    this.selection = selection;
+    this.baseRange = selection.getRangeAt(0);
+    this.wordLimit = Math.max(0, wordLimit | 0);
+    this.root = this.resolveRoot(container);
+  }
+
+  extract(): SelectionContext {
+    const selected = this.normalize(this.selection.toString());
+
+    const before = this.extractBefore();
+    const after = this.extractAfter();
+
+    const { before: clippedBefore, after: clippedAfter } = this.fitToWordLimit(
+      before,
+      after,
+      this.wordLimit,
+    );
+
+    return {
+      beforeContext: clippedBefore,
+      selectedText: selected,
+      afterContext: clippedAfter,
+    };
+  }
+
+  private resolveRoot(container?: Element): Element {
+    const startIn = (el: Element) => el.contains(this.baseRange.startContainer);
+    const endIn = (el: Element) => el.contains(this.baseRange.endContainer);
+
+    if (container) {
+      if (!startIn(container) || !endIn(container)) {
+        throw new Error(
+          "getSelectionContext: selection must be inside the provided container",
+        );
+      }
+      return container;
+    }
+
+    // Heuristic: prefer article/main/section ancestors; fall back to body
+    const anchorEl =
+      this.baseRange.commonAncestorContainer.nodeType === Node.ELEMENT_NODE
+        ? (this.baseRange.commonAncestorContainer as Element)
+        : (this.baseRange.commonAncestorContainer.parentElement ??
+          document.body);
+
+    const articley =
+      anchorEl.closest?.('article, main, section, [role="article"]') ?? null;
+
+    return (articley as Element) || document.body;
+  }
+
+  private extractBefore(): string {
+    const r = document.createRange();
+    r.setStart(this.root, 0);
+    r.setEnd(this.baseRange.startContainer, this.baseRange.startOffset);
+    return this.extractRangeText(r);
+  }
+
+  private extractAfter(): string {
+    const r = document.createRange();
+    r.setStart(this.baseRange.endContainer, this.baseRange.endOffset);
+    r.setEnd(this.root, this.root.childNodes.length);
+    return this.extractRangeText(r);
+  }
+
+  // Use cloneContents to strip unwanted nodes, then normalize whitespace
+  private extractRangeText(r: Range): string {
+    const frag = r.cloneContents();
+    // Remove non-content elements commonly present in documents
+    try {
+      frag
+        .querySelectorAll?.("script, style, noscript, iframe, svg, canvas")
+        .forEach((el) => el.remove());
+    } catch {
+      // querySelectorAll may not exist in very old environments; ignore
+    }
+    const txt = frag.textContent ?? "";
+    return this.normalize(txt);
+  }
+
+  private normalize(s: string): string {
+    return s
+      .replace(/\u00A0/g, " ") // nbsp -> space
+      .replace(/\s+/g, " ") // collapse whitespace
+      .trim();
+  }
+
+  private fitToWordLimit(beforeText: string, afterText: string, limit: number) {
+    if (limit <= 0) {
+      return { before: "", after: "" };
+    }
+
+    const bWords = beforeText ? beforeText.split(/\s+/) : [];
+    const aWords = afterText ? afterText.split(/\s+/) : [];
+
+    const desiredBefore = Math.ceil(limit / 2);
+    const desiredAfter = Math.floor(limit / 2);
+
+    let takeBefore = Math.min(bWords.length, desiredBefore);
+    let takeAfter = Math.min(aWords.length, desiredAfter);
+
+    // Rebalance leftover to whichever side still has words; prefer forward (after) first
+    let leftover = limit - (takeBefore + takeAfter);
+    while (leftover > 0 && takeAfter < aWords.length) {
+      takeAfter++;
+      leftover--;
+    }
+    while (leftover > 0 && takeBefore < bWords.length) {
+      takeBefore++;
+      leftover--;
+    }
+
+    const beforeSlice = bWords.slice(Math.max(0, bWords.length - takeBefore));
+    const afterSlice = aWords.slice(0, takeAfter);
+
+    const beforeTruncated = takeBefore < bWords.length;
+    const afterTruncated = takeAfter < aWords.length;
+
+    const before = (beforeTruncated ? "... " : "") + beforeSlice.join(" ");
+    const after = afterSlice.join(" ") + (afterTruncated ? " ..." : "");
+
+    return { before, after };
+  }
+}
+
+export function getSelectionContext(
+  selection: Selection,
+  container?: Element,
+  wordLimit = 400,
+): SelectionContext {
+  const extractor = new SelectionContextExtractor(
+    selection,
+    container,
+    wordLimit,
+  );
+  return extractor.extract();
+}

--- a/packages/extension/src/content/smartContext.ts
+++ b/packages/extension/src/content/smartContext.ts
@@ -1,0 +1,73 @@
+/**
+ * Smart context extraction for building ChatGPT prompts
+ */
+
+import { getSettings } from "../common/storage";
+import { renderTemplate } from "../common/template";
+import { toTextFragmentUrl } from "../common/textFragment";
+import type { ContextPayload } from "../common/types";
+import { getSelectionContext } from "./selection";
+
+export interface BuiltContext {
+  payload: ContextPayload;
+  prompt: string;
+}
+
+export async function buildContextPayload(
+  wordLimit?: number,
+): Promise<BuiltContext | null> {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) {
+    return null;
+  }
+
+  const settings = await getSettings();
+  const limit = wordLimit ?? settings.wordLimit;
+
+  try {
+    const context = getSelectionContext(selection, undefined, limit);
+
+    const pageTitle = document.title;
+    const url = location.href;
+    const fragmentUrl = toTextFragmentUrl(url, context.selectedText);
+
+    const payload: ContextPayload = {
+      pageTitle,
+      url,
+      fragmentUrl,
+      selection: context.selectedText,
+      beforeContext: context.beforeContext,
+      afterContext: context.afterContext,
+    };
+
+    // Combine before and after context for the template
+    const combinedContext = [
+      payload.beforeContext,
+      payload.selection,
+      payload.afterContext,
+    ]
+      .filter(Boolean)
+      .join("\n\n");
+
+    // Use the first selection template or fall back to legacy promptTemplate
+    const template =
+      settings.templates.find((t) => t.type === "selection") ||
+      settings.templates[0];
+    const templateString = template
+      ? template.template
+      : settings.promptTemplate || "";
+
+    const prompt = renderTemplate(templateString, {
+      pageTitle: payload.pageTitle,
+      url: payload.url,
+      fragmentUrl: payload.fragmentUrl || "",
+      selection: payload.selection,
+      context: combinedContext,
+    });
+
+    return { payload, prompt };
+  } catch (err) {
+    console.error("Failed to build context payload:", err);
+    return null;
+  }
+}

--- a/packages/extension/src/panel/index.html
+++ b/packages/extension/src/panel/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Copy with Context - Side Panel</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./panel.tsx"></script>
+  </body>
+</html>

--- a/packages/extension/src/panel/panel.css
+++ b/packages/extension/src/panel/panel.css
@@ -1,0 +1,187 @@
+/**
+ * Styles for the side panel UI
+ */
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  color: #1a1a1a;
+  background: #ffffff;
+}
+
+.panel {
+  padding: 16px;
+  max-width: 600px;
+}
+
+.panel-empty {
+  padding: 48px 16px;
+  text-align: center;
+  color: #6b7280;
+}
+
+.panel-empty p {
+  margin-bottom: 8px;
+}
+
+.panel-empty-hint {
+  font-size: 13px;
+  color: #9ca3af;
+}
+
+.panel-section {
+  margin-bottom: 32px;
+  padding-bottom: 32px;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.panel-section:last-child {
+  border-bottom: none;
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+
+.panel-title {
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 16px;
+  color: #1a1a1a;
+}
+
+.panel-meta {
+  margin-bottom: 16px;
+  padding: 12px;
+  background: #f9fafb;
+  border-radius: 6px;
+  font-size: 13px;
+}
+
+.panel-meta-item {
+  margin-bottom: 8px;
+}
+
+.panel-meta-item:last-child {
+  margin-bottom: 0;
+}
+
+.panel-meta-item strong {
+  color: #374151;
+  margin-right: 6px;
+}
+
+.panel-link {
+  color: #3b82f6;
+  text-decoration: none;
+  word-break: break-all;
+}
+
+.panel-link:hover {
+  text-decoration: underline;
+}
+
+.panel-field {
+  margin-bottom: 16px;
+}
+
+.panel-label {
+  display: block;
+  font-weight: 500;
+  margin-bottom: 8px;
+  color: #374151;
+}
+
+.panel-readonly {
+  padding: 12px;
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  font-size: 13px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+.panel-textarea {
+  width: 100%;
+  padding: 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font-family: ui-monospace, monospace;
+  font-size: 13px;
+  line-height: 1.6;
+  resize: vertical;
+  background: #ffffff;
+}
+
+.panel-textarea:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.panel-textarea[readonly] {
+  background: #f9fafb;
+  cursor: default;
+}
+
+.panel-hint {
+  font-size: 13px;
+  color: #6b7280;
+  margin-bottom: 12px;
+}
+
+.panel-button {
+  width: 100%;
+  padding: 10px 16px;
+  background: #ffffff;
+  color: #374151;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.panel-button:hover {
+  background: #f9fafb;
+  border-color: #9ca3af;
+}
+
+.panel-button:active {
+  background: #f3f4f6;
+}
+
+.panel-button-primary {
+  background: #3b82f6;
+  color: white;
+  border-color: #3b82f6;
+}
+
+.panel-button-primary:hover {
+  background: #2563eb;
+  border-color: #2563eb;
+}
+
+.panel-button-primary:active {
+  background: #1d4ed8;
+  border-color: #1d4ed8;
+}
+
+.panel-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.panel-button:disabled:hover {
+  background: #3b82f6;
+  border-color: #3b82f6;
+}

--- a/packages/extension/src/panel/panel.tsx
+++ b/packages/extension/src/panel/panel.tsx
@@ -1,0 +1,199 @@
+/**
+ * Side Panel UI for Copy with Context extension
+ */
+
+import React, { useState, useEffect } from "react";
+import { createRoot } from "react-dom/client";
+import { getSettings } from "../common/storage";
+import { renderTemplate } from "../common/template";
+import type { ContextPayload } from "../common/types";
+import "./panel.css";
+
+interface CaptureState {
+  payload: ContextPayload | null;
+  prompt: string;
+}
+
+function Panel() {
+  const [capture, setCapture] = useState<CaptureState | null>(null);
+  const [outline, setOutline] = useState("");
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    loadLastCapture();
+
+    // Listen for storage changes
+    // Note: Use chrome.storage.onChanged, not chrome.storage.session.onChanged
+    const listener = (
+      changes: Record<string, chrome.storage.StorageChange>,
+      areaName: string,
+    ) => {
+      if (areaName === "session" && changes.lastCapture) {
+        loadLastCapture();
+      }
+    };
+    chrome.storage.onChanged.addListener(listener);
+
+    return () => {
+      chrome.storage.onChanged.removeListener(listener);
+    };
+  }, []);
+
+  async function loadLastCapture() {
+    try {
+      const result = await chrome.storage.session.get("lastCapture");
+      if (result.lastCapture) {
+        const payload = result.lastCapture as ContextPayload;
+
+        // Use the stored prompt if available (for consistency with what was copied)
+        // Otherwise fall back to regenerating it
+        let prompt = payload.prompt;
+
+        if (!prompt) {
+          const settings = await getSettings();
+          const combinedContext = [
+            payload.beforeContext,
+            payload.selection,
+            payload.afterContext,
+          ]
+            .filter(Boolean)
+            .join("\n\n");
+
+          // Use the first selection template or fall back to legacy promptTemplate
+          const template =
+            settings.templates.find((t) => t.type === "selection") ||
+            settings.templates[0];
+          const templateString = template
+            ? template.template
+            : settings.promptTemplate || "";
+
+          prompt = renderTemplate(templateString, {
+            pageTitle: payload.pageTitle,
+            url: payload.url,
+            fragmentUrl: payload.fragmentUrl || "",
+            selection: payload.selection,
+            context: combinedContext,
+          });
+        }
+
+        setCapture({ payload, prompt });
+      }
+    } catch (err) {
+      console.error("Failed to load last capture:", err);
+    }
+  }
+
+  async function copyPrompt() {
+    if (!capture) return;
+    await navigator.clipboard.writeText(capture.prompt);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  async function showOutlineOverlay() {
+    if (!outline.trim()) return;
+
+    try {
+      const [tab] = await chrome.tabs.query({
+        active: true,
+        currentWindow: true,
+      });
+      if (tab?.id) {
+        await chrome.tabs.sendMessage(tab.id, {
+          type: "SHOW_OVERLAY",
+          outline: outline.trim(),
+        });
+      }
+    } catch (err) {
+      console.error("Failed to show overlay:", err);
+    }
+  }
+
+  if (!capture || !capture.payload) {
+    return (
+      <div className="panel">
+        <div className="panel-empty">
+          <p>No capture yet.</p>
+          <p className="panel-empty-hint">
+            Right-click on selected text and choose "Copy with context" to get
+            started.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="panel">
+      <div className="panel-section">
+        <h2 className="panel-title">Captured Context</h2>
+        <div className="panel-meta">
+          <div className="panel-meta-item">
+            <strong>Page:</strong> {capture.payload.pageTitle}
+          </div>
+          <div className="panel-meta-item">
+            <strong>URL:</strong>{" "}
+            <a
+              href={capture.payload.fragmentUrl || capture.payload.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="panel-link"
+            >
+              {capture.payload.url}
+            </a>
+          </div>
+        </div>
+
+        <div className="panel-field">
+          <label className="panel-label">Selection:</label>
+          <div className="panel-readonly">{capture.payload.selection}</div>
+        </div>
+
+        <div className="panel-field">
+          <label className="panel-label">ChatGPT Prompt:</label>
+          <textarea
+            className="panel-textarea"
+            value={capture.prompt}
+            readOnly
+            rows={10}
+          />
+        </div>
+
+        <button className="panel-button" onClick={copyPrompt}>
+          {copied ? "Copied!" : "Copy Prompt"}
+        </button>
+      </div>
+
+      <div className="panel-section">
+        <h2 className="panel-title">Paste Outline</h2>
+        <p className="panel-hint">
+          Paste the outline from ChatGPT here and click "Show Overlay" to
+          display it on the page.
+        </p>
+
+        <textarea
+          className="panel-textarea"
+          placeholder="Paste outline from ChatGPT..."
+          value={outline}
+          onChange={(e) => setOutline(e.target.value)}
+          rows={8}
+        />
+
+        <button
+          className="panel-button panel-button-primary"
+          onClick={showOutlineOverlay}
+          disabled={!outline.trim()}
+        >
+          Show Overlay
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// Mount the React app
+const container = document.getElementById("root");
+if (container) {
+  const root = createRoot(container);
+  root.render(<Panel />);
+}

--- a/packages/extension/src/popup/popup.css
+++ b/packages/extension/src/popup/popup.css
@@ -1,0 +1,123 @@
+/**
+ * Styles for the popup UI
+ */
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  color: #1a1a1a;
+  background: #ffffff;
+  width: 360px;
+}
+
+.popup {
+  display: flex;
+  flex-direction: column;
+  min-height: 400px;
+}
+
+.popup-header {
+  padding: 20px;
+  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  color: white;
+  text-align: center;
+}
+
+.popup-title {
+  font-size: 20px;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.popup-subtitle {
+  font-size: 13px;
+  opacity: 0.9;
+}
+
+.popup-content {
+  padding: 20px;
+  flex: 1;
+}
+
+.popup-instruction {
+  margin-bottom: 24px;
+}
+
+.popup-step {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.popup-step:last-child {
+  margin-bottom: 0;
+}
+
+.popup-step-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  background: #3b82f6;
+  color: white;
+  border-radius: 50%;
+  font-size: 12px;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.popup-step div {
+  flex: 1;
+  padding-top: 2px;
+}
+
+.popup-step strong {
+  color: #1a1a1a;
+}
+
+.popup-button {
+  width: 100%;
+  padding: 12px 16px;
+  background: #3b82f6;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.popup-button:hover {
+  background: #2563eb;
+}
+
+.popup-button:active {
+  background: #1d4ed8;
+}
+
+.popup-footer {
+  padding: 16px 20px;
+  border-top: 1px solid #e5e7eb;
+  text-align: center;
+}
+
+.popup-link {
+  color: #3b82f6;
+  text-decoration: none;
+  font-size: 13px;
+}
+
+.popup-link:hover {
+  text-decoration: underline;
+}

--- a/packages/extension/src/popup/popup.html
+++ b/packages/extension/src/popup/popup.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Copy with Context</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./popup.tsx"></script>
+  </body>
+</html>

--- a/packages/extension/src/popup/popup.tsx
+++ b/packages/extension/src/popup/popup.tsx
@@ -1,0 +1,86 @@
+/**
+ * Popup UI for Copy with Context extension
+ */
+
+import React from "react";
+import { createRoot } from "react-dom/client";
+import "./popup.css";
+
+function Popup() {
+  async function openSidePanel() {
+    try {
+      const [tab] = await chrome.tabs.query({
+        active: true,
+        currentWindow: true,
+      });
+      if (tab?.id) {
+        await chrome.sidePanel.open({ tabId: tab.id });
+        window.close();
+      }
+    } catch (err) {
+      console.error("Failed to open side panel:", err);
+    }
+  }
+
+  return (
+    <div className="popup">
+      <div className="popup-header">
+        <h1 className="popup-title">Copy with Context</h1>
+        <p className="popup-subtitle">
+          Extract text with smart context for ChatGPT
+        </p>
+      </div>
+
+      <div className="popup-content">
+        <div className="popup-instruction">
+          <div className="popup-step">
+            <span className="popup-step-number">1</span>
+            <div>
+              <strong>Select text</strong> on any webpage
+            </div>
+          </div>
+          <div className="popup-step">
+            <span className="popup-step-number">2</span>
+            <div>
+              <strong>Right-click</strong> and choose "Copy with context"
+            </div>
+          </div>
+          <div className="popup-step">
+            <span className="popup-step-number">3</span>
+            <div>
+              <strong>Paste</strong> into ChatGPT to get an outline
+            </div>
+          </div>
+          <div className="popup-step">
+            <span className="popup-step-number">4</span>
+            <div>
+              <strong>Open side panel</strong> to paste outline back
+            </div>
+          </div>
+        </div>
+
+        <button className="popup-button" onClick={openSidePanel}>
+          Open Side Panel
+        </button>
+      </div>
+
+      <div className="popup-footer">
+        <a
+          href="https://github.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="popup-link"
+        >
+          Documentation
+        </a>
+      </div>
+    </div>
+  );
+}
+
+// Mount the React app
+const container = document.getElementById("root");
+if (container) {
+  const root = createRoot(container);
+  root.render(<Popup />);
+}

--- a/packages/extension/tsconfig.json
+++ b/packages/extension/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["chrome", "vite/client"],
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/extension/vite.config.content.ts
+++ b/packages/extension/vite.config.content.ts
@@ -1,0 +1,33 @@
+import { resolve } from "node:path";
+import { defineConfig } from "vite";
+
+// Separate config for content script - must be IIFE format
+export default defineConfig({
+  build: {
+    outDir: "dist",
+    emptyOutDir: false,
+    lib: {
+      entry: resolve(__dirname, "src/content/contentScript.ts"),
+      name: "ContentScript",
+      formats: ["iife"],
+      fileName: () => "content/contentScript.js",
+    },
+    rollupOptions: {
+      external: ["chrome"],
+      output: {
+        entryFileNames: "content/contentScript.js",
+        assetFileNames: (assetInfo) => {
+          if (assetInfo.name?.endsWith(".css")) {
+            return "content.css";
+          }
+          return "[name][extname]";
+        },
+        extend: true,
+        // Make chrome global available
+        globals: {
+          chrome: "chrome",
+        },
+      },
+    },
+  },
+});

--- a/packages/extension/vite.config.ts
+++ b/packages/extension/vite.config.ts
@@ -1,0 +1,73 @@
+import { copyFileSync } from "node:fs";
+import { resolve } from "node:path";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [
+    react(),
+    {
+      name: "copy-manifest-and-icons",
+      closeBundle() {
+        const dist = resolve(__dirname, "dist");
+        const publicDir = resolve(__dirname, "public");
+
+        // Copy manifest
+        copyFileSync(
+          resolve(publicDir, "manifest.json"),
+          resolve(dist, "manifest.json"),
+        );
+
+        // Copy icons
+        for (const size of [16, 48, 128]) {
+          copyFileSync(
+            resolve(publicDir, `icon${size}.svg`),
+            resolve(dist, `icon${size}.svg`),
+          );
+        }
+      },
+    },
+  ],
+  publicDir: false, // Disable default public dir copying
+  build: {
+    outDir: "dist",
+    emptyOutDir: true,
+    rollupOptions: {
+      input: {
+        background: resolve(__dirname, "src/background/service_worker.ts"),
+        // content script built separately with vite.config.content.ts
+        panel: resolve(__dirname, "src/panel/index.html"),
+        popup: resolve(__dirname, "src/popup/popup.html"),
+      },
+      output: {
+        entryFileNames: (chunkInfo) => {
+          // Background script and content script should be in their respective folders
+          if (chunkInfo.name === "background") {
+            return "background/service_worker.js";
+          }
+          if (chunkInfo.name === "content") {
+            return "content/contentScript.js";
+          }
+          return "[name].js";
+        },
+        chunkFileNames: "chunks/[name]-[hash].js",
+        assetFileNames: (assetInfo) => {
+          const name = assetInfo.name || "";
+          if (name.endsWith(".css")) {
+            // Keep CSS with content script
+            if (name.includes("contentScript")) {
+              return "content/contentScript.css";
+            }
+            // Other CSS files go to root
+            return "[name][extname]";
+          }
+          return "assets/[name][extname]";
+        },
+      },
+    },
+    // Ensure source maps for debugging
+    sourcemap: process.env.NODE_ENV === "development",
+    // Don't minify in development for easier debugging
+    minify: process.env.NODE_ENV !== "development",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ catalogs:
       version: 1.9.4
     '@types/bun':
       specifier: latest
-      version: 1.3.0
+      version: 1.3.2
     '@types/node':
       specifier: ^22.10.2
       version: 22.18.9
@@ -87,6 +87,43 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.7.1)(@vitest/browser@3.2.4)(jsdom@25.0.1)(lightningcss@1.30.1)(msw@2.11.6(@types/node@24.7.1)(typescript@5.9.3))
+
+  packages/extension:
+    dependencies:
+      '@mozilla/readability':
+        specifier: ^0.6.0
+        version: 0.6.0
+      react:
+        specifier: ^19
+        version: 19.2.0
+      react-dom:
+        specifier: ^19
+        version: 19.2.0(react@19.2.0)
+    devDependencies:
+      '@biomejs/biome':
+        specifier: 'catalog:'
+        version: 1.9.4
+      '@types/chrome':
+        specifier: ^0.0.278
+        version: 0.0.278
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.18.9
+      '@types/react':
+        specifier: ^19.0.3
+        version: 19.2.2
+      '@types/react-dom':
+        specifier: ^19.0.2
+        version: 19.2.1(@types/react@19.2.2)
+      '@vitejs/plugin-react':
+        specifier: ^4
+        version: 4.7.0(vite@6.3.6(@types/node@22.18.9)(jiti@2.6.1)(lightningcss@1.30.1))
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vite:
+        specifier: 'catalog:'
+        version: 6.3.6(@types/node@22.18.9)(jiti@2.6.1)(lightningcss@1.30.1)
 
   packages/pdf-render:
     dependencies:
@@ -208,7 +245,7 @@ importers:
         version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@types/bun':
         specifier: 'catalog:'
-        version: 1.3.0(@types/react@19.2.2)
+        version: 1.3.2(@types/react@19.2.2)
       '@types/lodash':
         specifier: ^4.17.20
         version: 4.17.20
@@ -814,6 +851,10 @@ packages:
   '@mixmark-io/domino@2.2.0':
     resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
 
+  '@mozilla/readability@0.6.0':
+    resolution: {integrity: sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==}
+    engines: {node: '>=14.0.0'}
+
   '@mswjs/interceptors@0.40.0':
     resolution: {integrity: sha512-EFd6cVbHsgLa6wa4RljGj6Wk75qoHxUSyc5asLyyPSyuhIcdS2Q3Phw6ImS1q+CkALthJRShiYfKANcQMuMqsQ==}
     engines: {node: '>=18'}
@@ -1164,11 +1205,14 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
-  '@types/bun@1.3.0':
-    resolution: {integrity: sha512-+lAGCYjXjip2qY375xX/scJeVRmZ5cY0wyHYyCYxNcdEXrQ4AOe3gACgd4iQ8ksOslJtW4VNxBJ8llUwc3a6AA==}
+  '@types/bun@1.3.2':
+    resolution: {integrity: sha512-t15P7k5UIgHKkxwnMNkJbWlh/617rkDGEdSsDbu+qNHTaz9SKf7aC8fiIlUdD5RPpH6GEkP0cK7WlvmrEBRtWg==}
 
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
+
+  '@types/chrome@0.0.278':
+    resolution: {integrity: sha512-PDIJodOu7o54PpSOYLybPW/MDZBCjM1TKgf31I3Q/qaEbNpIH09rOM3tSEH3N7Q+FAqb1933LhF8ksUPYeQLNg==}
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
@@ -1181,6 +1225,15 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/filesystem@0.0.36':
+    resolution: {integrity: sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==}
+
+  '@types/filewriter@0.0.33':
+    resolution: {integrity: sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==}
+
+  '@types/har-format@1.2.16':
+    resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -1394,8 +1447,8 @@ packages:
   builtin-status-codes@3.0.0:
     resolution: {integrity: sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==}
 
-  bun-types@1.3.0:
-    resolution: {integrity: sha512-u8X0thhx+yJ0KmkxuEo9HAtdfgCBaM/aI9K90VQcQioAmkVp3SG3FkwWGibUFz3WdXAdcsqOcbU40lK7tbHdkQ==}
+  bun-types@1.3.2:
+    resolution: {integrity: sha512-i/Gln4tbzKNuxP70OWhJRZz1MRfvqExowP7U6JKoI8cntFrtxg7RJK3jvz7wQW54UuvNC8tbKHHri5fy74FVqg==}
     peerDependencies:
       '@types/react': ^19
 
@@ -3456,6 +3509,8 @@ snapshots:
 
   '@mixmark-io/domino@2.2.0': {}
 
+  '@mozilla/readability@0.6.0': {}
+
   '@mswjs/interceptors@0.40.0':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
@@ -3741,15 +3796,20 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.4
 
-  '@types/bun@1.3.0(@types/react@19.2.2)':
+  '@types/bun@1.3.2(@types/react@19.2.2)':
     dependencies:
-      bun-types: 1.3.0(@types/react@19.2.2)
+      bun-types: 1.3.2(@types/react@19.2.2)
     transitivePeerDependencies:
       - '@types/react'
 
   '@types/chai@5.2.2':
     dependencies:
       '@types/deep-eql': 4.0.2
+
+  '@types/chrome@0.0.278':
+    dependencies:
+      '@types/filesystem': 0.0.36
+      '@types/har-format': 1.2.16
 
   '@types/debug@4.1.12':
     dependencies:
@@ -3762,6 +3822,14 @@ snapshots:
       '@types/estree': 1.0.8
 
   '@types/estree@1.0.8': {}
+
+  '@types/filesystem@0.0.36':
+    dependencies:
+      '@types/filewriter': 0.0.33
+
+  '@types/filewriter@0.0.33': {}
+
+  '@types/har-format@1.2.16': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -4083,7 +4151,7 @@ snapshots:
 
   builtin-status-codes@3.0.0: {}
 
-  bun-types@1.3.0(@types/react@19.2.2):
+  bun-types@1.3.2(@types/react@19.2.2):
     dependencies:
       '@types/node': 24.7.1
       '@types/react': 19.2.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
   - packages/sqlite-browser
   - packages/pdf-render
   - packages/pdf-render/playground
+  - packages/extension
 
 catalog:
   "@biomejs/biome": ^1.9.4


### PR DESCRIPTION
Add a Chrome extension that captures selected text with smart surrounding context for ChatGPT analysis and displays outlines back on the original page.

Features:
- Right-click context menu 'Copy with context' on selected text
- Smart context extraction using SelectionContextExtractor (adapted from reader)
- Auto-formats into ChatGPT-ready template with page metadata
- React-based side panel for viewing captured context and pasting outlines
- Shadow DOM overlay to display outlines without CSS conflicts
- Text Fragment URLs for deep linking back to selection

Architecture:
- Service worker: context menu, message routing, side panel management
- Content script (IIFE): selection capture, context extraction, overlay UI
- Side panel: React UI for prompt editing and outline pasting
- Popup: Quick instructions and side panel access

Technical highlights:
- Vite build with separate configs for ES modules (service worker, UI) and IIFE (content script)
- Chrome MV3 manifest with proper permissions and content script injection
- chrome.storage.session.setAccessLevel() to enable content script storage access
- Explicit chrome API access helpers for bundled IIFE context compatibility
- Selection text passed from context menu to handle cleared selections

Package structure:
- packages/extension/src/background/ - service worker
- packages/extension/src/content/ - content scripts and overlay
- packages/extension/src/panel/ - React side panel UI
- packages/extension/src/popup/ - React popup UI
- packages/extension/src/common/ - shared types and utilities